### PR TITLE
feat: Use pyhf contrib download to get pallet from HEPData

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
-#FROM pyhf/pyhf:latest-stable
-FROM python:3.6-buster
+FROM python:3.8-buster
 
-RUN  apt-get update -y; apt-get install -y gcc python3-dev
+RUN apt-get update -y && \
+    apt-get install -y \
+        gcc \
+        python3-dev && \
+    apt-get -y autoclean && \
+    apt-get -y autoremove && \
+    rm -rf /var/lib/apt/lists/*
 COPY requirements.txt .
-RUN pip install -r requirements.txt && pip install funcx-endpoint
+RUN pip install --upgrade pip setuptools wheel && \
+    pip install -r requirements.txt && \
+    pip install "funcx-endpoint==0.0.3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-funcx
-IPython
-tblib
-pyhf
+funcx==0.0.5
+IPython~=7.20.0
+tblib~=1.7.0
+pyhf[contrib]~=0.6.0


### PR DESCRIPTION
This PR adds `pyhf`'s `contrib` extra as a requirement, and stipulates a compatible release with `pyhf` `v0.6.0` at the patch level of SemVer to ensure this API exists. It does so to take advantage of this to easily get the entire `pyhf` pallet from the central location of the published analysis HEPData repo. This places both the background only workspace JSON and the signal patchset in a user defined directory

```
# Example
$ pyhf contrib download --verbose https://doi.org/10.17182/hepdata.90607.v3/r3 1Lbb-pallet
1Lbb-pallet/patchset.json
1Lbb-pallet/README.md
1Lbb-pallet/BkgOnly.json
```

and ensures all requirements are available at runtime for submission to FuncX. Additionally use compatible release syntax with all requirements in `requirements.txt`.